### PR TITLE
Implement Phase 3 template modeling and add example/hybrid templates

### DIFF
--- a/docs/command-log.md
+++ b/docs/command-log.md
@@ -1,5 +1,11 @@
 # Command log (key commands)
 
 - `cat Agents.md`
+- `cat ImplementationPlan.md`
 - `rg --files -g 'AGENTS.md' -g 'Agents.md'`
+- `sed -n '1,200p' ontology/ttf.ttl`
+- `sed -n '200,400p' ontology/ttf.ttl`
+- `sed -n '1,200p' docs/phase-0-summary.md`
+- `sed -n '1,200p' docs/command-log.md`
+- `sed -n '1,200p' docs/ttf-source-notes.md`
 - `curl -L --max-time 20 https://raw.githubusercontent.com/InterWorkAlliance/TokenTaxonomyFramework/main/README.md | head -n 200`

--- a/docs/phase-3-summary.md
+++ b/docs/phase-3-summary.md
@@ -1,0 +1,18 @@
+# Phase 3 summary: template, formula, and definition modeling
+
+## Phase 3 scope
+- Model token templates as compositions of formulas and definitions.
+- Represent artifact references in formulas and definitions.
+- Encode hybrid token composition with parent/child relationships.
+- Add an example template expression aligned with the TTF grammar.
+
+## Implemented ontology updates
+- Added object properties to connect templates to formulas and definitions and to reference artifacts.
+- Added a formula expression datatype for rendering example syntax.
+- Added artifacts for base types and property sets to enable formula/definition references.
+- Added example template, formula, and definition individuals with the example expression `[τ {~d,SC} + φSKU]`.
+- Added hybrid template individuals with parent/child and composition links.
+
+## Phase 3 completion criteria status
+- **Hybrid structures expressible with parent/child and composes relations:** ✅ Met (hybrid template individuals).
+- **Template elements link base types, behaviors, groups, and property sets:** ✅ Met (example template/formula/definition individuals).

--- a/ontology/ttf.ttl
+++ b/ontology/ttf.ttl
@@ -137,6 +137,21 @@ ttf:childOf rdf:type owl:ObjectProperty ;
   rdfs:domain ttf:TokenTemplate ;
   rdfs:range ttf:TokenTemplate .
 
+ttf:hasFormula rdf:type owl:ObjectProperty ;
+  rdfs:label "has formula" ;
+  rdfs:domain ttf:TokenTemplate ;
+  rdfs:range ttf:TokenFormula .
+
+ttf:hasDefinition rdf:type owl:ObjectProperty ;
+  rdfs:label "has definition" ;
+  rdfs:domain ttf:TokenTemplate ;
+  rdfs:range ttf:TokenDefinition .
+
+ttf:referencesArtifact rdf:type owl:ObjectProperty ;
+  rdfs:label "references artifact" ;
+  rdfs:domain owl:Thing ;
+  rdfs:range ttf:Artifact .
+
 ### Data properties
 
 ttf:symbol rdf:type owl:DatatypeProperty ;
@@ -157,6 +172,11 @@ ttf:description rdf:type owl:DatatypeProperty ;
 ttf:version rdf:type owl:DatatypeProperty ;
   rdfs:label "version" ;
   rdfs:domain ttf:Artifact ;
+  rdfs:range rdfs:Literal .
+
+ttf:expression rdf:type owl:DatatypeProperty ;
+  rdfs:label "expression" ;
+  rdfs:domain ttf:TokenFormula ;
   rdfs:range rdfs:Literal .
 
 ### Token Classification Hierarchy (TCH)
@@ -236,3 +256,59 @@ ttf:DelegableBehavior ttf:influences ttf:TransferableBehavior .
 ttf:SingletonBehavior owl:differentFrom ttf:DivisibleBehavior .
 
 ttf:Singleton owl:disjointWith ttf:Divisible .
+
+### Templates, formulas, and definitions (Phase 3)
+
+ttf:FungibleBaseType rdf:type ttf:BaseType , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "Fungible Base Type" ;
+  ttf:symbol "τ" .
+
+ttf:NonFungibleBaseType rdf:type ttf:BaseType , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "Non-Fungible Base Type" ;
+  ttf:symbol "τ**" .
+
+ttf:SKUPropertySet rdf:type ttf:PropertySet , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "SKU Property Set" ;
+  ttf:description "Property set for SKU attributes." ;
+  ttf:symbol "φSKU" .
+
+ttf:ExampleFormula rdf:type ttf:TokenFormula , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "Example Formula" ;
+  ttf:expression "[τ {~d,SC} + φSKU]" ;
+  ttf:referencesArtifact ttf:FungibleBaseType ,
+    ttf:SupplyControl ,
+    ttf:SKUPropertySet .
+
+ttf:ExampleDefinition rdf:type ttf:TokenDefinition , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "Example Definition" ;
+  ttf:description "Definition for the example template with explicit artifact references." ;
+  ttf:referencesArtifact ttf:FungibleBaseType ,
+    ttf:SupplyControl ,
+    ttf:SKUPropertySet .
+
+ttf:ExampleTemplate rdf:type ttf:TokenTemplate , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "Example Template" ;
+  ttf:symbol "[τ {~d,SC} + φSKU]" ;
+  ttf:hasFormula ttf:ExampleFormula ;
+  ttf:hasDefinition ttf:ExampleDefinition ;
+  ttf:hasBaseType ttf:FungibleBaseType ;
+  ttf:hasGroup ttf:SupplyControl ;
+  ttf:hasPropertySet ttf:SKUPropertySet .
+
+ttf:HybridParentTemplate rdf:type ttf:TokenTemplate , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "Hybrid Parent Template" ;
+  ttf:hasBaseType ttf:FungibleBaseType ;
+  ttf:hasBehavior ttf:TransferableBehavior .
+
+ttf:HybridChildTemplate rdf:type ttf:TokenTemplate , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "Hybrid Child Template" ;
+  ttf:hasBaseType ttf:NonFungibleBaseType ;
+  ttf:childOf ttf:HybridParentTemplate ;
+  ttf:hasBehavior ttf:SingletonBehavior .
+
+ttf:HybridTemplate rdf:type ttf:TokenTemplate , ttf:Artifact , owl:NamedIndividual ;
+  rdfs:label "Hybrid Template" ;
+  ttf:parentOf ttf:HybridChildTemplate ;
+  ttf:composes ttf:HybridChildTemplate ;
+  ttf:hasBaseType ttf:FungibleBaseType ;
+  ttf:hasBehavior ttf:TransferableBehavior .


### PR DESCRIPTION
### Motivation
- Extend the ontology to model Token Templates as composed of reusable `TokenFormula` and `TokenDefinition` artifacts to support Phase 3 of the Implementation Plan. 
- Provide concrete example and hybrid template individuals so template composition and artifact referencing can be expressed and reasoned over in the TTL ontology.

### Description
- Added new object properties `ttf:hasFormula`, `ttf:hasDefinition`, and `ttf:referencesArtifact`, and a formula expression datatype `ttf:expression` to `ontology/ttf.ttl` to link templates, formulas, definitions, and referenced artifacts.
- Introduced artifact individuals `ttf:FungibleBaseType`, `ttf:NonFungibleBaseType`, and `ttf:SKUPropertySet` and a sample formula/definition pair `ttf:ExampleFormula` / `ttf:ExampleDefinition` with an expression value of `"[τ {~d,SC} + φSKU]"` in `ontology/ttf.ttl`.
- Added an example template `ttf:ExampleTemplate` that connects the formula/definition and references base type, group, and property set, and added hybrid template individuals `ttf:HybridParentTemplate`, `ttf:HybridChildTemplate`, and `ttf:HybridTemplate` to demonstrate parent/child and `composes` relationships in `ontology/ttf.ttl`.
- Added documentation `docs/phase-3-summary.md` describing the Phase 3 scope and what was implemented, and updated `docs/command-log.md` to reflect the workflow commands exercised.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968fc1724cc8323a855abf166a12736)