### PR TITLE
Add Dockerized Fuseki environment and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Token Taxonomy Framework (TTF) OWL Ontology
+
+## Overview
+This repository contains an OWL ontology representation of the InterWork Alliance Token Taxonomy Framework (TTF), expressed in Turtle (`ontology/ttf.ttl`). It also includes documentation for each implementation phase and a Dockerized Apache Jena Fuseki environment for querying the ontology.
+
+## Repository Layout
+- `ontology/ttf.ttl` — canonical ontology output in Turtle.
+- `docs/` — phase summaries and source notes.
+- `docker/` — Docker assets for running Apache Jena Fuseki.
+- `shacl/` — mounted workspace for SHACL shapes.
+
+## Running the Dockerized Query Environment
+### Prerequisites
+- Docker and Docker Compose (v2 plugin).
+
+### Start Fuseki
+```bash
+docker compose up --build
+```
+
+The Fuseki UI will be available at:
+- `http://localhost:3030/`
+
+The SPARQL query endpoint is:
+- `http://localhost:3030/ttf/query`
+
+### Example Query
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+SELECT ?class
+WHERE {
+  ?class rdf:type owl:Class .
+}
+LIMIT 20
+```
+
+### SHACL Workspace
+Place SHACL shape files in `shacl/` on the host. They will be mounted into the container at `/opt/ttf/shacl` for future validation workflows.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  fuseki:
+    build:
+      context: .
+      dockerfile: docker/fuseki/Dockerfile
+    ports:
+      - "3030:3030"
+    volumes:
+      - fuseki-data:/fuseki-base
+      - ./shacl:/opt/ttf/shacl
+
+volumes:
+  fuseki-data:

--- a/docker/fuseki/Dockerfile
+++ b/docker/fuseki/Dockerfile
@@ -1,0 +1,13 @@
+FROM apache/jena-fuseki:5.1.0
+
+ENV FUSEKI_BASE=/fuseki-base
+
+COPY docker/fuseki/ttf-config.ttl /opt/ttf/ttf-config.ttl
+COPY docker/fuseki/start-fuseki.sh /opt/ttf/start-fuseki.sh
+COPY ontology/ttf.ttl /opt/ttf/ttf.ttl
+
+RUN chmod +x /opt/ttf/start-fuseki.sh
+
+EXPOSE 3030
+
+ENTRYPOINT ["/opt/ttf/start-fuseki.sh"]

--- a/docker/fuseki/start-fuseki.sh
+++ b/docker/fuseki/start-fuseki.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+DATASET_DIR="${FUSEKI_BASE}/databases/ttf"
+ONTOLOGY_SRC="/opt/ttf/ttf.ttl"
+
+if [ ! -d "$DATASET_DIR" ] || [ -z "$(ls -A "$DATASET_DIR" 2>/dev/null)" ]; then
+  mkdir -p "$DATASET_DIR"
+  tdb2.tdbloader --loc "$DATASET_DIR" "$ONTOLOGY_SRC"
+fi
+
+exec fuseki-server --config=/opt/ttf/ttf-config.ttl

--- a/docker/fuseki/ttf-config.ttl
+++ b/docker/fuseki/ttf-config.ttl
@@ -1,0 +1,28 @@
+@prefix : <#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix tdb2: <http://jena.apache.org/2016/tdb#> .
+
+[] a fuseki:Server ;
+  fuseki:services (
+    :service_ttf
+  ) .
+
+:service_ttf a fuseki:Service ;
+  fuseki:name "ttf" ;
+  fuseki:dataset :dataset_ttf ;
+  fuseki:endpoint [
+    fuseki:operation fuseki:query ;
+    fuseki:name "query"
+  ] ;
+  fuseki:endpoint [
+    fuseki:operation fuseki:update ;
+    fuseki:name "update"
+  ] ;
+  fuseki:endpoint [
+    fuseki:operation fuseki:gsp-rw ;
+    fuseki:name "data"
+  ] .
+
+:dataset_ttf a tdb2:DatasetTDB2 ;
+  tdb2:location "/fuseki-base/databases/ttf" .

--- a/docs/phase-6-summary.md
+++ b/docs/phase-6-summary.md
@@ -1,0 +1,31 @@
+# Phase 6 Summary — Dockerized Query Environment (Apache Jena)
+
+## Outcomes
+- Added a Dockerized Apache Jena Fuseki environment that loads `ontology/ttf.ttl` on startup.
+- Included a Fuseki configuration and startup script to initialize the TDB2 dataset only when empty.
+- Added a SHACL workspace directory that is mounted into the container for future constraint work.
+- Documented how to run and query the container, including a sample SPARQL query.
+
+## Key Files
+- `docker/fuseki/Dockerfile`
+- `docker/fuseki/start-fuseki.sh`
+- `docker/fuseki/ttf-config.ttl`
+- `docker-compose.yml`
+- `shacl/README.md`
+
+## Run Instructions
+1. `docker compose up --build`
+2. Open the Fuseki UI at `http://localhost:3030/`.
+3. Query endpoint: `http://localhost:3030/ttf/query`.
+
+## Sample SPARQL Query
+```sparql
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+SELECT ?class
+WHERE {
+  ?class rdf:type owl:Class .
+}
+LIMIT 20
+```

--- a/shacl/README.md
+++ b/shacl/README.md
@@ -1,0 +1,4 @@
+# SHACL workspace
+
+Place SHACL shape files in this directory to mount them into the Fuseki container
+at `/opt/ttf/shacl` for future validation workflows.


### PR DESCRIPTION
### Motivation
- Implement Phase 6 to provide a reproducible, local query environment for the TTF ontology using Apache Jena Fuseki and to document how to run and query it.
- Enable future validation workflows by providing a SHACL workspace mount and a preload mechanism for the canonical `ontology/ttf.ttl` dataset.

### Description
- Add a Fuseki Docker image and startup loader that preloads `ontology/ttf.ttl` into a TDB2 dataset on first run via `docker/fuseki/Dockerfile` and `docker/fuseki/start-fuseki.sh`.
- Add a Fuseki assembler configuration `docker/fuseki/ttf-config.ttl` and a `docker-compose.yml` service exposing the SPARQL endpoint at `http://localhost:3030/ttf/query`.
- Add repository documentation including `README.md` with run instructions and `docs/phase-6-summary.md` describing Phase 6 outcomes and a sample SPARQL query.
- Add a SHACL workspace (`shacl/README.md`) and mount it into the container for future shape files.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6969e617f03c8323bda110d687d0a7c6)